### PR TITLE
Add instruction writing and class names fix.

### DIFF
--- a/src/core/jvm/instructions/AbstractBranchInstruction.js
+++ b/src/core/jvm/instructions/AbstractBranchInstruction.js
@@ -1,6 +1,6 @@
 const AbstractInstruction = require('./AbstractInstruction');
 
-export default class BranchInstruction extends AbstractInstruction {
+export default class AbstractBranchInstruction extends AbstractInstruction {
 
   constructor(idx, opcode) {
     super(idx, opcode);

--- a/src/core/jvm/instructions/AbstractInstruction.js
+++ b/src/core/jvm/instructions/AbstractInstruction.js
@@ -24,6 +24,6 @@ export default class AbstractInstruction {
   }
 
   write(buffer) {
-    
+    buffer.writeByte(this.opcode);
   }
 }

--- a/src/core/jvm/instructions/ArithmeticInstruction.js
+++ b/src/core/jvm/instructions/ArithmeticInstruction.js
@@ -14,4 +14,8 @@ export default class ArithmeticInstruction extends AbstractInstruction {
   read(buffer) {
     this.instruction.read(buffer);
   }
+
+  write(buffer) {
+    this.instruction.write(buffer);
+  }
 }

--- a/src/core/jvm/instructions/BranchInstruction.js
+++ b/src/core/jvm/instructions/BranchInstruction.js
@@ -14,4 +14,9 @@ export default class BranchInstruction extends AbstractBranchInstruction {
     super.read(buffer);
     super.branchOffset = buffer.short();
   }
+
+  write(buffer) {
+    super.write(buffer);
+    buffer.writeShort(super.branchOffset);
+  }
 }

--- a/src/core/jvm/instructions/CastInstruction.js
+++ b/src/core/jvm/instructions/CastInstruction.js
@@ -14,4 +14,8 @@ export default class CastInstruction extends AbstractInstruction {
   read(buffer) {
     this.instruction.read(buffer);
   }
+
+  write(buffer) {
+    this.instruction.write(buffer);
+  }
 }

--- a/src/core/jvm/instructions/ConstantInstruction.js
+++ b/src/core/jvm/instructions/ConstantInstruction.js
@@ -14,4 +14,8 @@ export default class ConstantInstruction extends AbstractInstruction {
   read(buffer) {
     this.instruction.read(buffer);
   }
+
+  write(buffer) {
+    this.instruction.write(buffer);
+  }
 }

--- a/src/core/jvm/instructions/FieldInstruction.js
+++ b/src/core/jvm/instructions/FieldInstruction.js
@@ -1,6 +1,6 @@
 const ImmediateShortInstruction = require('./ImmediateShortInstruction');
 
-export default class BranchInstruction extends ImmediateShortInstruction {
+export default class FieldInstruction extends ImmediateShortInstruction {
 
   constructor(idx, opcode) {
     super(idx, opcode);

--- a/src/core/jvm/instructions/ImmediateByteInstruction.js
+++ b/src/core/jvm/instructions/ImmediateByteInstruction.js
@@ -16,4 +16,13 @@ export default class ImmediateByteInstruction extends AbstractInstruction {
     super.read(buffer);
     this.val = (this.wide ? buffer.short() : buffer.byte());
   }
+
+  write(buffer) {
+    super.write(buffer);
+    if (this.wide) {
+      buffer.writeShort(this.val);
+    } else {
+      buffer.writeByte(this.val);
+    }
+  }
 }

--- a/src/core/jvm/instructions/ImmediateShortInstruction.js
+++ b/src/core/jvm/instructions/ImmediateShortInstruction.js
@@ -15,4 +15,9 @@ export default class ImmediateShortInstruction extends AbstractInstruction {
     super.read(buffer);
     this.val = buffer.short();
   }
+
+  write(buffer) {
+    super.write(buffer);
+    buffer.writeShort(this.val);
+  }
 }

--- a/src/core/jvm/instructions/IncrementInstruction.js
+++ b/src/core/jvm/instructions/IncrementInstruction.js
@@ -15,4 +15,13 @@ export default class IncrementInstruction extends ImmediateByteInstruction {
   read(buffer) {
     this.increment = (this.wide ? buffer.short() : buffer.byte());
   }
+
+  write(buffer) {
+    super.write(buffer);
+    if (this.wide) {
+      buffer.writeShort(this.increment);
+    } else {
+      buffer.writeByte(this.increment);
+    }
+  }
 }

--- a/src/core/jvm/instructions/InvokeDynamicInstruction.js
+++ b/src/core/jvm/instructions/InvokeDynamicInstruction.js
@@ -15,4 +15,9 @@ export default class InvokeDynamicInstruction extends ImmediateShortInstruction 
     // next two bytes are always zero and thus discarded.
     buffer.short();
   }
+
+  write(buffer) {
+    super.write(buffer);
+    buffer.writeShort(0);
+  }
 }

--- a/src/core/jvm/instructions/InvokeInterfaceInstruction.js
+++ b/src/core/jvm/instructions/InvokeInterfaceInstruction.js
@@ -17,4 +17,10 @@ export default class InvokeInterfaceInstruction extends ImmediateShortInstructio
     // the next byte is always zero and thus discarded.
     buffer.byte();
   }
+
+  write(buffer) {
+    super.write(buffer);
+    buffer.writeByte(this.count);
+    buffer.writeByte(0);
+  }
 }

--- a/src/core/jvm/instructions/LookupSwitchInstruction.js
+++ b/src/core/jvm/instructions/LookupSwitchInstruction.js
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 const PaddedInstruction = require('./PaddedInstruction');
 const OffsetPair = require('../OffsetPair')
 
@@ -25,5 +27,16 @@ export default class LookupSwitchInstruction extends PaddedInstruction {
         let offset = buffer.int();
         this.offsetPairs.push(new OffsetPair(match, offset));
     }
+  }
+
+  write(buffer) {
+    super.write(buffer);
+    buffer.writeInt(this.defaultOffset);
+    let pairCount = this.offsetPairs.length;
+    buffer.writeInt(pairCount);
+    _.each(this.offsetPairs, offsetPair => {
+      buffer.writeInt(offsetPair.match);
+      buffer.writeInt(offsetPair.offset);
+    });
   }
 }

--- a/src/core/jvm/instructions/MethodInstruction.js
+++ b/src/core/jvm/instructions/MethodInstruction.js
@@ -1,6 +1,6 @@
 const ImmediateShortInstruction = require('./ImmediateShortInstruction');
 
-export default class BranchInstruction extends ImmediateShortInstruction {
+export default class MethodInstruction extends ImmediateShortInstruction {
 
   constructor(idx, opcode) {
     super(idx, opcode);

--- a/src/core/jvm/instructions/MultianewarrayInstruction.js
+++ b/src/core/jvm/instructions/MultianewarrayInstruction.js
@@ -14,4 +14,9 @@ export default class MultianewarrayInstruction extends ImmediateShortInstruction
   read(buffer) {
     this.dimensions = buffer.byte();
   }
+
+  write(buffer) {
+    super.write(buffer);
+    buffer.writeByte(this.dimensions);
+  }
 }

--- a/src/core/jvm/instructions/PaddedInstruction.js
+++ b/src/core/jvm/instructions/PaddedInstruction.js
@@ -22,4 +22,12 @@ export default class PaddedInstruction extends AbstractInstruction {
       buffer.byte();
     }
   }
+
+  write(buffer) {
+    super.write(buffer);
+    let bytesToWrite = this.paddingBytes(buffer.pos);
+    for (let i = 0; i < bytesToWrite; i++) {
+      buffer.writeByte(0);
+    }
+  }
 }

--- a/src/core/jvm/instructions/PushInstruction.js
+++ b/src/core/jvm/instructions/PushInstruction.js
@@ -14,4 +14,8 @@ export default class PushInstruction extends AbstractInstruction {
   read(buffer) {
     this.instruction.read(buffer);
   }
+
+  write(buffer) {
+    this.instruction.write(buffer);
+  }
 }

--- a/src/core/jvm/instructions/TableSwitchInstruction.js
+++ b/src/core/jvm/instructions/TableSwitchInstruction.js
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 const PaddedInstruction = require('./PaddedInstruction');
 
 export default class TableSwitchInstruction extends PaddedInstruction {
@@ -26,5 +28,15 @@ export default class TableSwitchInstruction extends PaddedInstruction {
     for (let i = 0; i < offsetCount; i++) {
       this.jumpOffsets[i] = buffer.int();
     }
+  }
+
+  write(buffer) {
+    super.write(buffer);
+    buffer.writeInt(this.defaultOffset);
+    buffer.writeInt(this.lowByte);
+    buffer.writeInt(this.highByte);
+    _.each(this.jumpOffsets, jumpOffset => {
+      buffer.writeInt(jumpOffset);
+    });
   }
 }

--- a/src/core/jvm/instructions/VariableInstruction.js
+++ b/src/core/jvm/instructions/VariableInstruction.js
@@ -18,6 +18,10 @@ export default class VariableInstruction extends AbstractInstruction {
     this.instruction.read(buffer);
   }
 
+  write(buffer) {
+    this.instruction.write(buffer);
+  }
+
   get var() {
     if (this.instruction.constructor.name === 'ImmediateByteInstruction') {
       return this.instruction.val;

--- a/src/core/jvm/instructions/WideBranchInstruction.js
+++ b/src/core/jvm/instructions/WideBranchInstruction.js
@@ -9,4 +9,14 @@ export default class WideBranchInstruction extends AbstractBranchInstruction {
   get size() {
     return super.size + 4;
   }
+
+  read(buffer) {
+    super.read(buffer);
+    super.branchOffset = buffer.int();
+  }
+
+  write(buffer) {
+    super.write(buffer);
+    buffer.writeInt(super.branchOffset);
+  }
 }


### PR DESCRIPTION
- AbstractInstruction#write is filled out and all classes extending it.
- I also fixed the class names for FieldInstruction/MethodInstruction, as both were named 'BranchInstruction.'

refs #8
