### PR TITLE
Refactor wrapped instruction classes to lower code duplication

### DIFF
--- a/src/core/jvm/instructions/ArithmeticInstruction.js
+++ b/src/core/jvm/instructions/ArithmeticInstruction.js
@@ -1,21 +1,8 @@
-const AbstractInstruction = require('./AbstractInstruction');
+const InstructionWrapper = require('./InstructionWrapper');
 
-export default class ArithmeticInstruction extends AbstractInstruction {
+export default class ArithmeticInstruction extends InstructionWrapper {
 
   constructor(instruction) {
-    super(instruction.idx, instruction.opcode);
-    this.instruction = instruction;
-  }
-
-  get size() {
-    return this.instruction.size;
-  }
-
-  read(buffer) {
-    this.instruction.read(buffer);
-  }
-
-  write(buffer) {
-    this.instruction.write(buffer);
+    super(instruction);
   }
 }

--- a/src/core/jvm/instructions/CastInstruction.js
+++ b/src/core/jvm/instructions/CastInstruction.js
@@ -1,21 +1,8 @@
-const AbstractInstruction = require('./AbstractInstruction');
+const InstructionWrapper = require('./InstructionWrapper');
 
-export default class CastInstruction extends AbstractInstruction {
+export default class CastInstruction extends InstructionWrapper {
 
   constructor(instruction) {
-    super(instruction.idx, instruction.opcode);
-    this.instruction = instruction;
-  }
-
-  get size() {
-    return this.instruction.size;
-  }
-
-  read(buffer) {
-    this.instruction.read(buffer);
-  }
-
-  write(buffer) {
-    this.instruction.write(buffer);
+    super(instruction);
   }
 }

--- a/src/core/jvm/instructions/ConstantInstruction.js
+++ b/src/core/jvm/instructions/ConstantInstruction.js
@@ -1,21 +1,8 @@
-const AbstractInstruction = require('./AbstractInstruction');
+const InstructionWrapper = require('./InstructionWrapper');
 
-export default class ConstantInstruction extends AbstractInstruction {
+export default class ConstantInstruction extends InstructionWrapper {
 
   constructor(instruction) {
-    super(instruction.idx, instruction.opcode);
-    this.instruction = instruction;
-  }
-
-  get size() {
-    return this.instruction.size;
-  }
-
-  read(buffer) {
-    this.instruction.read(buffer);
-  }
-
-  write(buffer) {
-    this.instruction.write(buffer);
+    super(instruction);
   }
 }

--- a/src/core/jvm/instructions/InstructionWrapper.js
+++ b/src/core/jvm/instructions/InstructionWrapper.js
@@ -1,0 +1,21 @@
+const AbstractInstruction = require('./AbstractInstruction');
+
+export default class InstructionWrapper extends AbstractInstruction {
+
+  constructor(instruction) {
+    super(instruction.idx, instruction.opcode);
+    this.instruction = instruction;
+  }
+
+  get size() {
+    return this.instruction.size;
+  }
+
+  read(buffer) {
+    this.instruction.read(buffer);
+  }
+
+  write(buffer) {
+    this.instruction.write(buffer);
+  }
+}

--- a/src/core/jvm/instructions/PushInstruction.js
+++ b/src/core/jvm/instructions/PushInstruction.js
@@ -1,21 +1,8 @@
-const AbstractInstruction = require('./AbstractInstruction');
+const InstructionWrapper = require('./InstructionWrapper');
 
-export default class PushInstruction extends AbstractInstruction {
+export default class PushInstruction extends InstructionWrapper {
 
   constructor(instruction) {
-    super(instruction.idx, instruction.opcode);
-    this.instruction = instruction;
-  }
-
-  get size() {
-    return this.instruction.size;
-  }
-
-  read(buffer) {
-    this.instruction.read(buffer);
-  }
-
-  write(buffer) {
-    this.instruction.write(buffer);
+    super(instruction);
   }
 }

--- a/src/core/jvm/instructions/VariableInstruction.js
+++ b/src/core/jvm/instructions/VariableInstruction.js
@@ -1,25 +1,12 @@
 import * as _ from 'lodash';
 
-const AbstractInstruction = require('./AbstractInstruction');
+const InstructionWrapper = require('./InstructionWrapper');
 const ImmediateByteInstruction = require('./ImmediateByteInstruction');
 
-export default class VariableInstruction extends AbstractInstruction {
+export default class VariableInstruction extends InstructionWrapper {
 
   constructor(instruction) {
-    super(instruction.idx, instruction.opcode);
-    this.instruction = instruction;
-  }
-
-  get size() {
-    return this.instruction.size;
-  }
-
-  read(buffer) {
-    this.instruction.read(buffer);
-  }
-
-  write(buffer) {
-    this.instruction.write(buffer);
+    super(instruction);
   }
 
   get val() {


### PR DESCRIPTION
This refactor extracts the read/write methods along with
the size getter to a parent class `InstructionWrapper`.
All of the classes that now subclass `InstructionWrapper`
can override their parent method to change the behavior
of the above methods/getter if they need to do so by
implementing the relevant override method they need.
