### PR TITLE
Fix instruction type creation and Buffer security error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "jvm",
-  "version": "0.5.1",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/kylestev/jvm.js.git"
-  },
-  "engines": {
-    "node": ">=6.3"
-  },
-  "main": "./lib/index.js",
-  "scripts": {
-    "compile": "./node_modules/.bin/babel -d lib/ src/",
-    "docs": "./node_modules/.bin/esdoc -c .esdoc.json",
-    "lint": "eslint src",
-    "prepublish": "npm run compile",
-    "test": "./node_modules/.bin/eslint src"
-  },
-  "dependencies": {
-    "adm-zip": "^0.4.9",
-    "binary-parser": "^1.1.5",
-    "cjson": "^0.5.0",
-    "lodash": "^4.17.5"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.0.0",
-    "babel-eslint": "^5.0.0",
-    "babel-preset-es2015": "^6.5.0",
-    "esdoc": "^1.1.0",
-    "esdoc-importpath-plugin": "^1.0.2",
-    "esdoc-standard-plugin": "^1.0.0",
-    "eslint": "^1.7.3"
+    "name": "jvm",
+    "version": "0.5.2",
+    "license": "MIT",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/kylestev/jvm.js.git"
+    },
+    "engines": {
+      "node": ">=6.3"
+    },
+    "main": "./lib/index.js",
+    "scripts": {
+      "compile": "./node_modules/.bin/babel -d lib/ src/",
+      "docs": "./node_modules/.bin/esdoc -c .esdoc.json",
+      "lint": "eslint src",
+      "prepublish": "npm run compile",
+      "test": "./node_modules/.bin/eslint src"
+    },
+    "dependencies": {
+      "adm-zip": "^0.4.9",
+      "binary-parser": "^1.1.5",
+      "cjson": "^0.5.0",
+      "lodash": "^4.17.5"
+    },
+    "devDependencies": {
+      "babel-cli": "^6.0.0",
+      "babel-eslint": "^5.0.0",
+      "babel-preset-es2015": "^6.5.0",
+      "esdoc": "^1.1.0",
+      "esdoc-importpath-plugin": "^1.0.2",
+      "esdoc-standard-plugin": "^1.0.0",
+      "eslint": "^1.7.3"
+    }
   }
-}

--- a/src/core/jvm/instructions/AbstractBranchInstruction.js
+++ b/src/core/jvm/instructions/AbstractBranchInstruction.js
@@ -23,3 +23,5 @@ export default class AbstractBranchInstruction extends AbstractInstruction {
     return super.toString({ branchOffset: this.branchOffset, totalOffset: this.totalOffset });
   }
 }
+
+module.exports = AbstractBranchInstruction;

--- a/src/core/jvm/instructions/AbstractInstruction.js
+++ b/src/core/jvm/instructions/AbstractInstruction.js
@@ -50,3 +50,5 @@ export default class AbstractInstruction {
     return this.opname + ' [' + params + ']';
   }
 }
+
+module.exports = AbstractInstruction;

--- a/src/core/jvm/instructions/ArithmeticInstruction.js
+++ b/src/core/jvm/instructions/ArithmeticInstruction.js
@@ -7,3 +7,5 @@ export default class ArithmeticInstruction extends InstructionWrapper {
     super(instruction);
   }
 }
+
+module.exports = ArithmeticInstruction;

--- a/src/core/jvm/instructions/BranchInstruction.js
+++ b/src/core/jvm/instructions/BranchInstruction.js
@@ -27,3 +27,5 @@ export default class BranchInstruction extends AbstractBranchInstruction {
     });
   }
 }
+
+module.exports = BranchInstruction;

--- a/src/core/jvm/instructions/CastInstruction.js
+++ b/src/core/jvm/instructions/CastInstruction.js
@@ -7,3 +7,5 @@ export default class CastInstruction extends InstructionWrapper {
     super(instruction);
   }
 }
+
+module.exports = CastInstruction;

--- a/src/core/jvm/instructions/ConstantInstruction.js
+++ b/src/core/jvm/instructions/ConstantInstruction.js
@@ -38,3 +38,5 @@ export default class ConstantInstruction extends InstructionWrapper {
     return super.toString({ val: this.val });
   }
 }
+
+module.exports = InstructionWrapper;

--- a/src/core/jvm/instructions/FieldInstruction.js
+++ b/src/core/jvm/instructions/FieldInstruction.js
@@ -7,3 +7,5 @@ export default class FieldInstruction extends MemberInstruction {
     super(methodInfo, idx, opcode);
   }
 }
+
+module.exports = FieldInstruction;

--- a/src/core/jvm/instructions/ImmediateByteInstruction.js
+++ b/src/core/jvm/instructions/ImmediateByteInstruction.js
@@ -34,3 +34,5 @@ export default class ImmediateByteInstruction extends AbstractInstruction {
     });
   }
 }
+
+module.exports = ImmediateByteInstruction;

--- a/src/core/jvm/instructions/ImmediateShortInstruction.js
+++ b/src/core/jvm/instructions/ImmediateShortInstruction.js
@@ -29,3 +29,5 @@ export default class ImmediateShortInstruction extends AbstractInstruction {
     });
   }
 }
+
+module.exports = ImmediateShortInstruction;

--- a/src/core/jvm/instructions/IncrementInstruction.js
+++ b/src/core/jvm/instructions/IncrementInstruction.js
@@ -37,3 +37,5 @@ export default class IncrementInstruction extends ImmediateByteInstruction {
     return super.toString({ increment: this.increment });
   }
 }
+
+module.exports = IncrementInstruction;

--- a/src/core/jvm/instructions/InvokeDynamicInstruction.js
+++ b/src/core/jvm/instructions/InvokeDynamicInstruction.js
@@ -28,3 +28,5 @@ export default class InvokeDynamicInstruction extends ImmediateShortInstruction 
     });
   }
 }
+
+module.exports = InvokeDynamicInstruction;

--- a/src/core/jvm/instructions/InvokeInterfaceInstruction.js
+++ b/src/core/jvm/instructions/InvokeInterfaceInstruction.js
@@ -36,3 +36,5 @@ export default class InvokeInterfaceInstruction extends ImmediateShortInstructio
     return super.toString({ count: this.count });
   }
 }
+
+module.exports = InvokeInterfaceInstruction;

--- a/src/core/jvm/instructions/LookupSwitchInstruction.js
+++ b/src/core/jvm/instructions/LookupSwitchInstruction.js
@@ -54,3 +54,5 @@ export default class LookupSwitchInstruction extends PaddedInstruction {
     return super.toString({ defaultOffset: this.defaultOffset, offsetPairs: this.offsetPairs });
   }
 }
+
+module.exports = LookupSwitchInstruction;

--- a/src/core/jvm/instructions/MemberInstruction.js
+++ b/src/core/jvm/instructions/MemberInstruction.js
@@ -32,3 +32,5 @@ export default class MemberInstruction extends ImmediateShortInstruction {
     return super.toString({ name: this.name, desc: this.desc, owner: this.owner });
   }
 }
+
+module.exports = MemberInstruction;

--- a/src/core/jvm/instructions/MethodInstruction.js
+++ b/src/core/jvm/instructions/MethodInstruction.js
@@ -17,3 +17,5 @@ export default class MethodInstruction extends MemberInstruction {
     return parameterParser(this.desc);
   }
 }
+
+module.exports = MemberInstruction;

--- a/src/core/jvm/instructions/MultianewarrayInstruction.js
+++ b/src/core/jvm/instructions/MultianewarrayInstruction.js
@@ -32,3 +32,5 @@ export default class MultianewarrayInstruction extends ImmediateShortInstruction
     return super.toString({ dimensions: this.dimensions });
   }
 }
+
+module.exports = MultianewarrayInstruction;

--- a/src/core/jvm/instructions/PaddedInstruction.js
+++ b/src/core/jvm/instructions/PaddedInstruction.js
@@ -32,3 +32,5 @@ export default class PaddedInstruction extends AbstractInstruction {
     }
   }
 }
+
+module.exports = PaddedInstruction;

--- a/src/core/jvm/instructions/PushInstruction.js
+++ b/src/core/jvm/instructions/PushInstruction.js
@@ -15,3 +15,5 @@ export default class PushInstruction extends InstructionWrapper {
     return super.toString({ val: this.val });
   }
 }
+
+module.exports = PushInstruction;

--- a/src/core/jvm/instructions/TableSwitchInstruction.js
+++ b/src/core/jvm/instructions/TableSwitchInstruction.js
@@ -60,3 +60,5 @@ export default class TableSwitchInstruction extends PaddedInstruction {
     });
   }
 }
+
+module.exports = TableSwitchInstruction;

--- a/src/core/jvm/instructions/TypeInstruction.js
+++ b/src/core/jvm/instructions/TypeInstruction.js
@@ -20,3 +20,5 @@ export default class TypeInstruction extends ImmediateShortInstruction {
     return super.toString({ type: this.type });
   }
 }
+
+module.exports = TypeInstruction;

--- a/src/core/jvm/instructions/VariableInstruction.js
+++ b/src/core/jvm/instructions/VariableInstruction.js
@@ -32,3 +32,5 @@ export default class VariableInstruction extends InstructionWrapper {
     return super.toString({ val: this.val });
   }
 }
+
+module.exports = VariableInstruction;

--- a/src/core/jvm/instructions/WideBranchInstruction.js
+++ b/src/core/jvm/instructions/WideBranchInstruction.js
@@ -27,3 +27,5 @@ export default class WideBranchInstruction extends AbstractBranchInstruction {
     });
   }
 }
+
+module.exports = WideBranchInstruction;

--- a/src/core/parsers/BytecodeInstructions.js
+++ b/src/core/parsers/BytecodeInstructions.js
@@ -18,7 +18,7 @@ function extractCodeFromMethod(method) {
  */
 export function parseInstructions(method) {
   let code = extractCodeFromMethod(method);
-  let buffer = new NiceBuffer(new Buffer(code));
+  let buffer = new NiceBuffer(Buffer.from(code));
 
   let wide = false;
   let current = null;


### PR DESCRIPTION
I've also bumped the version number to 0.5.2 for publishing to npm